### PR TITLE
fixes bug when prepend https

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@ if [ -z "$REDIRECT_TARGET" ]; then
 	exit 1
 else
 	# Add https if not set
-	if ! [[ $REDIRECT_TARGET =~ ^http?:// ]]; then
+	if ! [[ $REDIRECT_TARGET =~ ^https?:// ]]; then
 		REDIRECT_TARGET="https://$REDIRECT_TARGET"
 	fi
 


### PR DESCRIPTION
Current `start.sh` script doesn't recognize `https` `REDIRECT_TARGET`.

If `REDIRECT_TARGET=https://some.domain.com`, it redirects to `https://https://some.domain.com`